### PR TITLE
Handling invalid types of content and request objects in pagination params

### DIFF
--- a/lib/pagination/adapter.js
+++ b/lib/pagination/adapter.js
@@ -1,4 +1,4 @@
-const { invalidPageNumberError, invalidLimitNumberError } = require('./errors');
+const { invalidPageNumberError, invalidLimitNumberError, invalidContentTypeError } = require('./errors');
 
 const minOffset = adapterParams =>
   adapterParams.page === 1 ? 0 : (adapterParams.page - 1) * adapterParams.limit;
@@ -20,6 +20,8 @@ const nextPage = adapterParams =>
   adapterParams.page >= totalPages(adapterParams) ? null : adapterParams.page + 1;
 
 const pageUrl = (adapterParams, pageParam) =>
+  typeof adapterParams.request === 'object' &&
+  adapterParams.request.constructor.name === 'IncomingMessage' &&
   pageParam
     ? `http://${adapterParams.request.headers.host}${adapterParams.request.url}?page=${pageParam}`
     : null;
@@ -37,8 +39,9 @@ const contentPagination = adapterParams => ({
 });
 
 const responseFormat = params => {
-  if (typeof params.page !== 'number' || params.page <= 0) throw invalidPageNumberError();
-  if (typeof params.limit !== 'number' || params.limit <= 0) throw invalidLimitNumberError();
+  if (!Number.isInteger(params.page) || params.page <= 0) throw invalidPageNumberError();
+  if (!Number.isInteger(params.limit) || params.limit <= 0) throw invalidLimitNumberError();
+  if (!Array.isArray(params.content)) throw invalidContentTypeError();
   return contentPagination(params);
 };
 

--- a/lib/pagination/errors.js
+++ b/lib/pagination/errors.js
@@ -1,15 +1,22 @@
 const customError = message => new Error(message);
 
 exports.invalidPageNumberError = () => {
-  const error = customError('Invalid Page Number');
+  const error = customError('The page number must be an integer greater than 0');
   error.name = 'InvalidPageNumber';
   Error.captureStackTrace(error, exports.invalidPageNumberError);
   return error;
 };
 
 exports.invalidLimitNumberError = () => {
-  const error = customError('Invalid Limit Number');
+  const error = customError('The limit number must be an integer greater than 0');
   error.name = 'InvalidLimitNumber';
   Error.captureStackTrace(error, exports.invalidLimitNumberError);
+  return error;
+};
+
+exports.invalidContentTypeError = () => {
+  const error = customError('The content must be an Array');
+  error.name = 'InvalidContentType';
+  Error.captureStackTrace(error, exports.invalidContentTypeError);
   return error;
 };

--- a/test/server.js
+++ b/test/server.js
@@ -1,7 +1,7 @@
 const http = require('http');
 const { testScenarios } = require('./server_test_scenarios');
 
-exports.createServer = (content = []) =>
+exports.createServer = content =>
   http.createServer((req, res) => {
     if (req.method === 'GET') {
       testScenarios.forEach(scenario => {

--- a/test/server_test_scenarios.js
+++ b/test/server_test_scenarios.js
@@ -36,5 +36,23 @@ exports.testScenarios = [
         res.write(JSON.stringify(error));
       }
     }
+  },
+  {
+    testUrl: '/index_content_type_exception',
+    action: (req, res, content) => {
+      try {
+        nodePagination.paginate(content, req, {});
+      } catch (error) {
+        res.writeHeader(500, { 'Content-Type': 'application/json' });
+        res.write(JSON.stringify(error));
+      }
+    }
+  },
+  {
+    testUrl: '/index_with_invalid_req_object',
+    action: (req, res, content) => {
+      res.writeHeader(200, { 'Content-Type': 'application/json' });
+      res.write(JSON.stringify(nodePagination.paginate(content, undefined, { limit: 5, page: 3 })));
+    }
   }
 ];


### PR DESCRIPTION
## Summary
* Added a new custom error `InvalidContentTypeError` for the cases in which a content that is not an array is sent to the `paginate` method.
* Added a validation to paginate properly, no matter if the `request` object is not an `IncomingMessage` object, in that case, the page urls will be null, but the pagination will still work.
* Corresponding tests for those cases were added.


This is a solution to the following issues: https://github.com/Wolox/pagination-node/issues/13 , https://github.com/Wolox/pagination-node/issues/14