### PR TITLE
[BugFix] Replacing next and previous page query params to avoid repeated page params

### DIFF
--- a/lib/pagination/adapter.js
+++ b/lib/pagination/adapter.js
@@ -19,20 +19,12 @@ const totalPages = adapterParams => Math.ceil(totalCount(adapterParams) / adapte
 const nextPage = adapterParams =>
   adapterParams.page >= totalPages(adapterParams) ? null : adapterParams.page + 1;
 
-const trimPageUrl = (originalUrl, newPageNum) => {
-  const newPageUrl = originalUrl.replace(/page=[0-9]+/, `page=${newPageNum}`);
-  return newPageUrl === originalUrl ? `${newPageUrl}&page=${newPageNum}` : newPageUrl;
-};
-
 const pageUrl = (adapterParams, pageParam) => {
   if (!pageParam) return null;
 
-  const { host } = adapterParams.request.headers;
-  const { url } = adapterParams.request;
-  if (!adapterParams.request.url.includes('?')) return `http://${host}${url}?page=${pageParam}`;
-
-  const newPageUrl = trimPageUrl(url, pageParam);
-  return `http://${host}${newPageUrl}`;
+  const urlObject = new URL(`http://${adapterParams.request.headers.host}${adapterParams.request.url}`);
+  urlObject.searchParams.set('page', pageParam);
+  return urlObject.toString();
 };
 
 const contentPagination = adapterParams => ({

--- a/lib/pagination/adapter.js
+++ b/lib/pagination/adapter.js
@@ -20,7 +20,7 @@ const nextPage = adapterParams =>
   adapterParams.page >= totalPages(adapterParams) ? null : adapterParams.page + 1;
 
 const trimPageUrl = (originalUrl, newPageNum) => {
-  const newPageUrl = originalUrl.replace(/page=./, `page=${newPageNum}`);
+  const newPageUrl = originalUrl.replace(/page=[0-9]+/, `page=${newPageNum}`);
   return newPageUrl === originalUrl ? `${newPageUrl}&page=${newPageNum}` : newPageUrl;
 };
 

--- a/lib/pagination/adapter.js
+++ b/lib/pagination/adapter.js
@@ -19,10 +19,21 @@ const totalPages = adapterParams => Math.ceil(totalCount(adapterParams) / adapte
 const nextPage = adapterParams =>
   adapterParams.page >= totalPages(adapterParams) ? null : adapterParams.page + 1;
 
-const pageUrl = (adapterParams, pageParam) =>
-  pageParam
-    ? `http://${adapterParams.request.headers.host}${adapterParams.request.url}?page=${pageParam}`
-    : null;
+const trimPageUrl = (originalUrl, newPageNum) => {
+  const newPageUrl = originalUrl.replace(/page=./, `page=${newPageNum}`);
+  return newPageUrl === originalUrl ? `${newPageUrl}&page=${newPageNum}` : newPageUrl;
+};
+
+const pageUrl = (adapterParams, pageParam) => {
+  if (!pageParam) return null;
+
+  const { host } = adapterParams.request.headers;
+  const { url } = adapterParams.request;
+  if (!adapterParams.request.url.includes('?')) return `http://${host}${url}?page=${pageParam}`;
+
+  const newPageUrl = trimPageUrl(url, pageParam);
+  return `http://${host}${newPageUrl}`;
+};
 
 const contentPagination = adapterParams => ({
   page: paginatedContent(adapterParams),
@@ -32,8 +43,8 @@ const contentPagination = adapterParams => ({
   previous_page: previousPage(adapterParams),
   current_page: adapterParams.page,
   next_page: nextPage(adapterParams),
-  previous_page_url: pageUrl(adapterParams, previousPage(adapterParams)),
-  next_page_url: pageUrl(adapterParams, nextPage(adapterParams))
+  previous_page_link: pageUrl(adapterParams, previousPage(adapterParams)),
+  next_page_link: pageUrl(adapterParams, nextPage(adapterParams))
 });
 
 const responseFormat = params => {

--- a/test/helpers/custom_pag_params.js
+++ b/test/helpers/custom_pag_params.js
@@ -6,6 +6,10 @@ exports.customPagParams = request => ({
   previous_page: 2,
   current_page: 3,
   next_page: 4,
-  previous_page_url: `${request.url}?page=2`,
-  next_page_url: `${request.url}?page=4`
+  previous_page_link: request.url.includes('?')
+    ? request.url.replace(/page=./, 'page=2')
+    : `${request.url}?page=2`,
+  next_page_link: request.url.includes('?')
+    ? request.url.replace(/page=./, 'page=4')
+    : `${request.url}?page=4`
 });

--- a/test/helpers/default_pag_params.js
+++ b/test/helpers/default_pag_params.js
@@ -8,6 +8,6 @@ exports.defaultPagParams = request => ({
   previous_page: null,
   current_page: nodePagination.defaultPage,
   next_page: 2,
-  previous_page_url: null,
-  next_page_url: `${request.url}?page=2`
+  previous_page_link: null,
+  next_page_link: `${request.url}?page=2`
 });

--- a/test/pagination/paginate.spec.js
+++ b/test/pagination/paginate.spec.js
@@ -9,15 +9,17 @@ const factory = require('../factory/fake_model');
 const testUrls = {
   index: '/index',
   indexWithParams: '/index_with_params',
+  indexQueryParams: '/index_query_params?page=3&limit=5',
   indexPageException: '/index_page_exception',
   indexLimitException: '/index_limit_exception'
 };
 const makeRequest = (url, content, method = 'get') => request(createServer(content))[method](url);
 
 describe.each`
-  description                             | testUrl                     | minSlice | maxSlice
-  ${'default pagination without options'} | ${testUrls.index}           | ${0}     | ${25}
-  ${'custom pagination with options'}     | ${testUrls.indexWithParams} | ${10}    | ${15}
+  description                              | testUrl                      | minSlice | maxSlice
+  ${'default pagination without options'}  | ${testUrls.index}            | ${0}     | ${25}
+  ${'custom pagination with options'}      | ${testUrls.indexWithParams}  | ${10}    | ${15}
+  ${'custom pagination with query params'} | ${testUrls.indexQueryParams} | ${10}    | ${15}
 `('Request $description passed', ({ description, testUrl, minSlice, maxSlice }) => {
   let fakeModels = undefined;
   let response = undefined;
@@ -43,8 +45,8 @@ describe.each`
     expect(responseBody.total_pages).toBe(pagParams.total_pages);
     expect(responseBody.previous_page).toBe(pagParams.previous_page);
     expect(responseBody.next_page).toBe(pagParams.next_page);
-    expect(responseBody.previous_page_url).toBe(pagParams.previous_page_url);
-    expect(responseBody.next_page_url).toBe(pagParams.next_page_url);
+    expect(responseBody.previous_page_link).toBe(pagParams.previous_page_link);
+    expect(responseBody.next_page_link).toBe(pagParams.next_page_link);
   });
 
   it('responds with a valid page', () => {

--- a/test/server_test_scenarios.js
+++ b/test/server_test_scenarios.js
@@ -36,5 +36,12 @@ exports.testScenarios = [
         res.write(JSON.stringify(error));
       }
     }
+  },
+  {
+    testUrl: '/index_query_params?page=3&limit=5',
+    action: (req, res, content) => {
+      res.writeHeader(200, { 'Content-Type': 'application/json' });
+      res.write(JSON.stringify(nodePagination.paginate(content, req, { limit: 5, page: 3 })));
+    }
   }
 ];


### PR DESCRIPTION
## Summary
* Now the `page` query param is being replaced properly, checking if the incoming url had such param or not, to decide where to put this param for `next_page_link` and `previous_page_link` pagination params, and therefore, avoid repeated page params for these links or wrong page links.
* `next_page_url` and `previous_page_url` pag params names were changed to `next_page_link` and `previous_page_link` according to the Wolox Api Restful Guidelines
* A new test case for query params in the url was added

This is a solution to this issue: https://github.com/Wolox/pagination-node/issues/42