### PR TITLE
Add limit to pagination response

### DIFF
--- a/lib/pagination/adapter.js
+++ b/lib/pagination/adapter.js
@@ -10,6 +10,8 @@ const paginatedContent = adapterParams =>
 
 const count = adapterParams => paginatedContent(adapterParams).length;
 
+const limit = adapterParams => adapterParams.limit;
+
 const totalCount = adapterParams => adapterParams.content.length;
 
 const previousPage = adapterParams => (adapterParams.page === 1 ? null : adapterParams.page - 1);
@@ -27,6 +29,7 @@ const pageUrl = (adapterParams, pageParam) =>
 const contentPagination = adapterParams => ({
   page: paginatedContent(adapterParams),
   count: count(adapterParams),
+  limit: limit(adapterParams),
   total_pages: totalPages(adapterParams),
   total_count: totalCount(adapterParams),
   previous_page: previousPage(adapterParams),

--- a/test/helpers/custom_pag_params.js
+++ b/test/helpers/custom_pag_params.js
@@ -1,6 +1,7 @@
 exports.customPagParams = request => ({
   page_count: 5,
   count: 5,
+  limit: 5,
   total_count: 30,
   total_pages: Math.ceil(30 / 5),
   previous_page: 2,

--- a/test/helpers/default_pag_params.js
+++ b/test/helpers/default_pag_params.js
@@ -3,6 +3,7 @@ const nodePagination = require('../..');
 exports.defaultPagParams = request => ({
   page_count: nodePagination.defaultLimit,
   count: nodePagination.defaultLimit,
+  limit: 25,
   total_count: 30,
   total_pages: Math.ceil(30 / nodePagination.defaultLimit),
   previous_page: null,

--- a/test/pagination/paginate.spec.js
+++ b/test/pagination/paginate.spec.js
@@ -45,6 +45,7 @@ describe.each`
     expect(responseBody.next_page).toBe(pagParams.next_page);
     expect(responseBody.previous_page_url).toBe(pagParams.previous_page_url);
     expect(responseBody.next_page_url).toBe(pagParams.next_page_url);
+    expect(responseBody.limit).toBe(pagParams.limit);
   });
 
   it('responds with a valid page', () => {


### PR DESCRIPTION
Added the limit used to paginate on the response of pagination-node as to follow the Wolox Guidelines: https://techguides.engineering.wolox.com.ar/backend/backend-standard-and-best-practices.html#31--pagination